### PR TITLE
Enable enqueuing updates for expired items when serving stale

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -258,7 +258,9 @@ func (ch *Cache[K, T]) Get(key K) Value[T] {
 		return v
 	}
 
-	if delta.Abs() <= ch.threshold {
+	inTreshold := delta < 0 && delta.Abs() <= ch.threshold
+	expired := delta >= 0
+	if inTreshold || expired {
 		// key is eligible for update
 		ch.enqueueUpdate(key)
 	}


### PR DESCRIPTION
Currently, the logic behaves like the following when the `ServeStale` is `true`.
```
|______________________ ____threshold window__________ ______________ ____threshold window x2________ ______expiry & no threshold__________|
0 min                   9 mins                         10 mins        11 mins
Add key here           Update                          Update         Update                          No Update
```

I adapted it to also enqueue an update in the expired after the second "threshold window".

Please let me know if the previous behavior was on purpose or if it was a bug. If it was not purpose, I will also create a test case.