### PR TITLE
Downgrade Go version compatibility from 1.23 to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/naughtygopher/pocache
 
-go 1.23
+go 1.22
 
 require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7


### PR DESCRIPTION
This PR downgrades the Go version compatibility of the library from 1.23 to 1.22. The goal is to ensure that the library remains accessible to projects still running Go 1.22, which is widely used and actively supported.

### Justification
- Broader Compatibility: Many software projects are still operating on Go 1.22 and may face challenges upgrading to 1.23 immediately. This change enables these projects to leverage the library without requiring a Go version upgrade.
- Supported Versions: Both Go 1.22 and 1.23 are officially supported as of now. According to the [Go end-of-life tracker](https://endoflife.date/go), Go 1.22 is still supported, with the latest patch version (1.22.11) released on 16 January 2025.
- Backward Compatibility: This change does not impact users already on Go 1.23 or newer versions while extending usability to systems running 1.22.
- Community Standards: Aligning with Go’s support lifecycle ensures inclusivity for projects across supported versions.

### Impact
No breaking changes are introduced. The library’s functionality remains intact for users on 1.23 while adding compatibility for Go 1.22.

If there are any concerns or suggestions regarding this adjustment, feedback is welcome!